### PR TITLE
Clean up repo docs and add packaging config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Items to ignore when downloading a zip
+pmpro-user-pages-banner.png export-ignore
+.gitattributes export-ignore
+.github export-ignore
+.gitignore export-ignore
+README.md export-ignore

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ __Please Note:__ GitHub is for bug reports and contributions only. If you have a
 
 * __Do not report potential security vulnerabilities here. Email them privately to [info@paidmembershipspro.com](mailto:info@paidmembershipspro.com) with the words "Security Vulnerability" in the subject.__
 * Submit a ticket for your issue, assuming one does not already exist.
-  * Raise it on our [Issue Tracker](https://github.com/strangerstudios/pmpro-lock-membership-level/issues/new/choose)
+  * Raise it on our [Issue Tracker](https://github.com/strangerstudios/pmpro-user-pages/issues/new/choose)
   * Clearly describe the issue including steps to reproduce the bug.
   * Make sure you fill in the earliest version that you know has the issue as well as the version of WordPress you're using.
 
@@ -20,7 +20,7 @@ __Please Note:__ GitHub is for bug reports and contributions only. If you have a
 * For bug fixes, checkout the DEV branch of the PMPro repository.
 * For new features and enhancements, checkout the branch for the version the feature is milestoned for.
 * Make sure to pull in any "upstream" changes first.
-	* Use `git remote add upstream https://github.com/strangerstudios/pmpro-lock-membership-level.git` to set the upstream repo
+	* Use `git remote add upstream https://github.com/strangerstudios/pmpro-user-pages.git` to set the upstream repo
 	* Use `git checkout dev` to get on the development branch.
 	* Use `git pull upstream dev` to get the latest updates.
 	* Use `git push` to push those updates to your fork.

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -1,8 +1,8 @@
 ### All Submissions:
 
-* [ ] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-lock-membership-level/blob/dev/.github/CONTRIBUTING.md)?
+* [ ] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-user-pages/blob/dev/.github/CONTRIBUTING.md)?
 * [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-lock-membership-level/pulls/) for the same update/change?
+* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-user-pages/pulls/) for the same update/change?
 
 <!-- Mark completed items with an [x] -->
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Mac stuff
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ### Welcome to the Paid Memberships Pro - User Pages GitHub Repository
 When a user checks out from a Paid Memberships Pro registration page, this Add On automatically creates a private page for them that only that user and WordPress administrators can access.
 
-For more information please visit [https://www.paidmembershipspro.com/add-ons/pmpro-user-pages/](https://www.paidmembershipspro.com/add-ons/pmpro-user-pages/)
+For more information please visit [the Add On documentation page for this plugin](https://www.paidmembershipspro.com/add-ons/pmpro-user-pages).
 
 ## Installation ##
 For detailed installation steps, visit the [documentation](https://www.paidmembershipspro.com/add-ons/pmpro-user-pages) page.
@@ -18,7 +18,7 @@ For detailed installation steps, visit the [documentation](https://www.paidmembe
 **Please ensure that once installing this version of the plugin to remove `-dev` from the plugin's folder name.**
 
 ## Bugs ##
-If you find an issue/bug, let us know by [creating a detailed GitHub issue](https://github.com/strangerstudios/pmpro-user-pages/issues/new).
+If you find an issue/bug, let us know by [creating a detailed GitHub issue](https://github.com/strangerstudios/pmpro-user-pages/issues/new/choose).
 
 ## Support ##
 This is a developer's portal for Paid Memberships Pro - User Pages. We do not offer support on this channel. **Any support related questions should be directed to [paidmembershipspro.com/support](https://www.paidmembershipspro.com/support/).**
@@ -28,11 +28,11 @@ We encourage and welcome any contribution to Paid Memberships Pro - User Pages. 
 
 There are various **ways to the help development** of Paid Memberships Pro - User Pages:
 
-1. Report [bugs/issues](https://github.com/strangerstudios/pmpro-user-pages/issues/new) on GitHub.
+1. Report [bugs/issues](https://github.com/strangerstudios/pmpro-user-pages/issues/new/choose) on GitHub.
 2. Work on any issues by submitting a Pull Request.
 
 Here are some ways for **non-developers to contribute** to Paid Memberships Pro - User Pages:
 
 1. Translate Paid Memberships Pro - User Pages into your own [language](https://www.paidmembershipspro.com/paid-memberships-pro-in-your-language/).
-2. [Purchase a paid membership](https://paidmembershipspro.com/pricing) to help fund ongoing development and bug fixes.
+2. [Purchase a plan](https://paidmembershipspro.com/pricing) to help fund ongoing development and bug fixes.
 3. Leave an honest review for [Paid Memberships Pro - User Pages](https://www.paidmembershipspro.com/submit-testimonial/).


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-user-pages/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-user-pages/pulls/) for the same update/change?

### Summary

Repository housekeeping on top of the latest `dev`:

- **Fix broken links**: `.github/CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.MD` still referenced `pmpro-lock-membership-level` (leftover from the add-on template). Now point at `pmpro-user-pages`.
- **README**: normalize filename to `README.md`, switch issue links to `/issues/new/choose` (template chooser), and update "Purchase a paid membership" → "Purchase a plan".
- **Packaging config**: add `.gitattributes` to `export-ignore` dev-only files from the distributed zip, and `.gitignore` for `.DS_Store`.

No functional code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)